### PR TITLE
fixed the case when issue was not stored because of the too short iss…

### DIFF
--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -5,7 +5,7 @@ class Issue < ActiveRecord::Base
   belongs_to :group, class_name: 'GroupedIssue', foreign_key: 'group_id'
   delegate :website, to: :group
   accepts_nested_attributes_for :messages
-  validates :message, presence: true, length: {minimum: 10}
+  validates :message, presence: true
   after_create :issue_created
 
   def error

--- a/lib/error_store/manager.rb
+++ b/lib/error_store/manager.rb
@@ -79,7 +79,7 @@ module ErrorStore
       issue.group_id = group.id
 
       # save the issue unless its been sampled
-      db_store(:issue) { issue.save } unless is_sample
+      db_store(:issue) { issue.save! } unless is_sample
 
       issue
     end


### PR DESCRIPTION
Changes proposed in this pull request:
- force saving an issue so we can catch exceptions when something goes wrong 
- remove minimum message length from our issue model
